### PR TITLE
Update GitHub Actions workflow for package handling and merging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
-          name: packages
+          name: debian-package-${{ matrix.container }}
           path: ./pkgs/*.deb
   
   release:
@@ -37,7 +37,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          name: packages
+          merge-multiple: true
           path: ./pkgs
       - name: Create release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Specify package naming in the upload step and enable multiple merges during the download process.