### PR TITLE
Add libtool-bin to build dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,7 @@ apt-get -y install \
     ed \
     msktutil \
     logrotate \
+    libtool-bin \
     libldap2-dev \
     libsasl2-dev \
     libssl-dev \


### PR DESCRIPTION
Include libtool-bin in the list of build dependencies to ensure proper functionality during the build process.